### PR TITLE
awesompd: fixed update_track for https streams

### DIFF
--- a/.config/awesome/awesompd/awesompd.lua
+++ b/.config/awesome/awesompd/awesompd.lua
@@ -972,7 +972,7 @@ function awesompd:update_track(file)
             -- Internet link. Internet radios change tracks, but the
             -- current file stays the same, so we should manually compare
             -- its title.
-            if string.match(new_file, "http://") then
+            if string.match(new_file, "http://") or string.match(new_file, "https://") then
                 album = non_empty(station) or ""
                 display_name = non_empty(title) or new_file
                 if display_name ~= self.current_track.display_name then


### PR DESCRIPTION
update_track() isn't called for https streams, this small change fixes that.